### PR TITLE
Refactor/reviewcards

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,14 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!-- <link rel="icon" href="%PUBLIC_URL%/favicon.ico" /> -->
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -19,13 +19,10 @@ const GET_REVIEWS = gql`
   }
 `;
 
-const foodIcon = new Icon({
-  iconUrl: '/dinner-icon.png',
-  iconSize: [35, 35]
-})
-
 const App = () => {
-const { loading, error, data } = useQuery(GET_REVIEWS);
+const { loading, error, data, refetch } = useQuery(GET_REVIEWS, {
+  pollInterval: 10000,
+});
 const [position, setPosition] = useState(null)
 const [lat, setLat] = useState(null)
 const [lng, setLng] = useState(null)
@@ -37,17 +34,21 @@ const LocationMarker = () => {
       setPosition({ lat, lng });
       setLat(lat.toString())
       setLng(lng.toString())
-      console.log(typeof lat)
       map.flyTo(e.latlng, map.getZoom());
     }
-  })
-
+  });
+  
   return position === null ? null : (
     <Marker position={position}>
       <Popup>Your Selected Location</Popup>
     </Marker>
   );
 };
+
+const foodIcon = new Icon({
+  iconUrl: '/dinner-icon.png',
+  iconSize: [35, 35]
+});
 
 const CustomPopup = ({ name, description }) => (
   <div className="custom-popup">
@@ -61,9 +62,7 @@ if (error) return <p>Error : {error.message}</p>;
 
   return (
     <div className='app'>
-      
-        <Form lat={lat} lng={lng}/>
-
+      <Form lat={lat} lng={lng} refetch={refetch}/>
       <MapContainer
         center={{ lat: 39.739235, lng: -104.990250 }}
         zoom={6}
@@ -85,7 +84,7 @@ if (error) return <p>Error : {error.message}</p>;
           </Marker>
         ))}
       </MapContainer>
-      <Review data={data}/>
+      <Review data={data} refetch={refetch}/>
     </div>
   );
 };

--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -30,17 +30,14 @@ const POST_REVIEW = gql`
   }
 `;
 
-const Form = ({ lat, lng }) => {
+const Form = ({ lat, lng, refetch }) => {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [photo, setPhoto] = useState("");
   const [postReview] = useMutation(POST_REVIEW);
-
-  console.log(typeof lat)
   
   const handlePhotoChange = (event) => {
     const selectedFile = event.target.files[0];
-    console.log(event.target.value)
     setPhoto(selectedFile)
   };
   
@@ -54,6 +51,7 @@ const Form = ({ lat, lng }) => {
   
   const submitForm = async (event) => {
     event.preventDefault();
+    refetch();
     try {
       const { data } = await postReview({
         variables: {
@@ -68,7 +66,7 @@ const Form = ({ lat, lng }) => {
       } catch (error) {
         console.error("Mutation error:", error);
       }
-    };
+  };
 
   return (
     <div className="form-container">

--- a/src/Components/Form/Form.js
+++ b/src/Components/Form/Form.js
@@ -35,6 +35,7 @@ const Form = ({ lat, lng, refetch }) => {
   const [description, setDescription] = useState("");
   const [photo, setPhoto] = useState("");
   const [postReview] = useMutation(POST_REVIEW);
+  const [mutationError, setMutationError] = useState(false)
   
   const handlePhotoChange = (event) => {
     const selectedFile = event.target.files[0];
@@ -63,14 +64,20 @@ const Form = ({ lat, lng, refetch }) => {
         },
       });
         console.log("Mutation response data:", data);
+        setMutationError(false)
       } catch (error) {
         console.error("Mutation error:", error);
+        setMutationError(true)
+        console.log(mutationError, 'this is mutation error')
       }
   };
 
   return (
     <div className="form-container">
       <img src={foodieLogo} className="logo" alt='application logo'></img>
+      <div className="error-container">
+        {mutationError ? <p>Oops: please ensure you've selected all fields</p> : <p></p>}
+      </div>
       <form onSubmit={submitForm} className="form">
         <input
           type="text"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './Components/App/App.js'
 import reportWebVitals from './reportWebVitals';
-import {  ApolloClient, InMemoryCache, ApolloProvider, gql } from '@apollo/client';
+import {  ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
 import { createUploadLink } from "apollo-upload-client";
 
 const client = new ApolloClient({
@@ -13,22 +13,22 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-client
-  .query({
-    query: gql`
-      query {
-        reviews {
-          id
-          name
-          description
-          photoUrl
-          lat
-          lng
-        }
-      }
-    `,
-  })
-  .then((result) => console.log(result));
+// client
+//   .query({
+//     query: gql`
+//       query {
+//         reviews {
+//           id
+//           name
+//           description
+//           photoUrl
+//           lat
+//           lng
+//         }
+//       }
+//     `,
+//   });
+  // .then((result) => console.log(result));
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
What I did:
Refactored to ensure that when a new review is posted, the user is able to see it at the top of the list of reviews without having to refresh the page. Used the `refetch` function provided by the `useQuery` hook in Apollo Client.
Additionally, added a new `state` for a mutation error: this state is set to true and the user will see a message informing them they need to select all required options to submit their review. 

Testing Notes/Extras: 
The error handling can and will be improved in a later PR. This implementation was introduced to assist while development continues. 
_New error in console_: some of the reviews do not have images. This throws an error that can be fixed by removing old reviews created while testing form and mutations. 

Did this break anything?
- [x]  No
- [ ]  Yes

Type of change
- [x]  New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Added testing for: 
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:
- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [x]  The code is DRY. If it's not, I tried my best